### PR TITLE
Revert "Run Scheduler with flask(no need for seperate container) "

### DIFF
--- a/clock.py
+++ b/clock.py
@@ -1,0 +1,22 @@
+import logging
+logging.basicConfig(
+    level=logging.DEBUG,
+    format='%(asctime)s - %(levelname)s - %(message)s'
+)
+from apscheduler.schedulers.blocking import BlockingScheduler
+from fetchStats import fetchStats
+# Use BlockingScheduler so the script stays alive
+sched = BlockingScheduler()
+
+# Schedule the job
+sched.add_job(fetchStats, 'interval', minutes=10)
+
+print("Worker started. Running initial fetch...")
+try:
+    fetchStats() # Run once on startup
+    print("Done!!")
+except Exception as e:
+    print(f"Error in initial fetch: {e}")
+
+# Start the scheduler (this will block and keep the container running)
+sched.start()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,17 @@ services:
     networks:
       - bf_shared_net
 
+  worker:
+    build: .
+    command: python clock.py
+    env_file:
+      - .env
+    volumes:
+      - ./data:/app/data
+    restart: always
+    networks:
+      - bf_shared_net
+
 networks:
   bf_shared_net:
     external: true

--- a/main.py
+++ b/main.py
@@ -1,4 +1,3 @@
-import atexit
 import logging
 from flask import Flask, render_template, jsonify, request
 import json
@@ -7,32 +6,8 @@ import utils.sql as sql
 import utils.html
 import utils.matrixbot as matrixbot
 import bleach
-from apscheduler.schedulers.background import BackgroundScheduler
-
-    
-logging.basicConfig(
-            level=logging.INFO,
-            format='%(asctime)s - %(levelname)s - %(message)s'
-)
 
 app = Flask(__name__)
-
-app.logger.setLevel(logging.INFO)
-sched = BackgroundScheduler()
-
-
-def start_scheduler():
-    sched.add_job(fetchStats, 'interval', minutes=10)
-
-    print("Worker started. Running initial fetch...")
-    try:
-        fetchStats()
-        print("Done!!")
-    except Exception as e:
-        print(f"Error in initial fetch: {e}")
-    sched.start()
-    print("Scheduler started. Will fetch stats every 10 minutes.")
-    atexit.register(lambda: sched.shutdown())
 
 @app.context_processor
 def inject_global_stats():
@@ -152,13 +127,12 @@ def api_compare():
 def not_found(e):
     return render_template("404.html")
 
-start_scheduler()
-
 if __name__ == '__main__':
     # You can keep this specifically for local testing if you want
+    app.logger.setLevel(logging.DEBUG)
+    
     logging.basicConfig(
             level=logging.DEBUG,
             format='%(asctime)s - %(levelname)s - %(message)s'
-)
-
+        )
     app.run(debug=True, use_reloader=True)

--- a/utils/network.py
+++ b/utils/network.py
@@ -92,7 +92,7 @@ async def async_get_request(endpoint:str,params: Optional[Dict[str, Any]] = None
 def get_request(endpoint:str,params: Optional[Dict[str, Any]] = None,baseurl=BASE_BLOCKFRONT_URL,timeout: float = 15.0):
     '''Syncronous Wrapper for async function'''
     output = asyncio.run(async_get_request(endpoint,params,baseurl=baseurl,timeout=timeout))
-    logger.info(f"error or smth: {output}" )
+    logger.info("error or smth", output)
     if output == '{"error":"cloud_disconnected"}':
         error_msg = f"Received 'cloud_disconnected' response for endpoint {endpoint}"
         logger.warning(error_msg)


### PR DESCRIPTION
Reverts Seth-the-cat/py_bf_historical#9

In hindsight this is less stable and means that guincon when running multiple workers will cause many schedulers to run.